### PR TITLE
Fix `spec_version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ parachain for smart contracts.
 If you have any questions, feel free to talk to us on [Element][k2] or on [Discord][l2]
 (in the [`ink_smart-contracts`](https://discord.com/channels/722223075629727774/765280480609828864) channel).
 
-**Note:** This used to be a standalone smart contract node used for the ink! workshop. We
+**Note:** This used to be a standalone smart contracts node used for the ink! workshop. We
 have moved the standalone node to [substrate-contracts-node](https://github.com/paritytech/substrate-contracts-node/).
 
 
@@ -27,19 +27,19 @@ have moved the standalone node to [substrate-contracts-node](https://github.com/
 
 This node is based on the
 [`substrate-parachain-template`](https://github.com/substrate-developer-hub/substrate-parachain-template/),
-which we configured to use Substrate's smart contract module ‒ the [`contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
+which we configured to use Substrate's smart contracts module ‒ the [`contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
 pallet.
 This `contracts` pallet takes smart contracts as WebAssembly blobs and defines an API
 for everything a smart contract needs (storage access, …).
-So as long as a programming language compiles to WebAssembly and there exists an implementation
+As long as a programming language compiles to WebAssembly and there exists an implementation
 of this API in it, you can write a smart contract for this pallet ‒ and thus for Canvas ‒ in
 that language.
 
-This is a list of smart contract languages you can currently choose from:
+This is a list of languages you can currently choose from:
 
 * [Parity's ink!](https://github.com/paritytech/ink) for Rust
 * [ask!](https://github.com/patractlabs/ask) for Assembly Script
-* [Solang](https://github.com/hyperledger-labs/solang) for Solidity
+* The [Solang](https://github.com/hyperledger-labs/solang) compiler for Solidity
 
 There are also different user interfaces and command-line tools you can use to deploy
 or interact with contracts:
@@ -47,7 +47,7 @@ or interact with contracts:
 * [Canvas UI](https://paritytech.github.io/canvas-ui/)
 * [polkadot-js](https://polkadot.js.org/apps/)
 
-If you are looking for a quickstart we can recommend
+If you are looking for a quickstart, we can recommend
 [ink!'s Guided Tutorial for Beginners](https://substrate.dev/substrate-contracts-workshop/#/0/building-your-contract).
 
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -199,7 +199,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("canvas"),
 	impl_name: create_runtime_str!("canvas"),
 	authoring_version: 1,
-	spec_version: 1,
+	spec_version: 13,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
As part of https://github.com/paritytech/canvas/pull/78 we did reset the `spec_version`.

We shouldn't have done this though since the type definitions for polkadot-js ([here](https://github.com/polkadot-js/apps/blob/master/packages/apps-config/src/api/spec/canvas.ts)) contain different types for the `spec_version`'s `[0, 8]`. So currently e.g. the polkadot-js UI tries to use those "old" types again. 