### PR TITLE
Place `resolver` key in correct place

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
-resolver = "2"
-
 [workspace]
+resolver = "2"
 members = [
     'node',
     'runtime',


### PR DESCRIPTION
I made a boo-boo when putting the experimental resolver in. This PR makes sure that we
_actually_ use it in builds.
