### PR TITLE
Publish Wasm runtime artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,6 +108,7 @@ build-linux:
     - time cargo test --release --all
     - mkdir -p ./artifacts/canvas-linux/
     - cp ${CARGO_TARGET_DIR}/release/canvas ./artifacts/canvas-linux/canvas
+    - cp ${CARGO_TARGET_DIR}/release/wbuild/canvas-runtime/canvas_runtime* ./artifacts/canvas-linux/
     - cp ./scripts/dockerfiles/canvas_injected.Dockerfile ./artifacts/canvas-linux/canvas_injected.Dockerfile
 
 ### stage:                         build-mac


### PR DESCRIPTION
This will add the Wasm runtime artifacts to our published artifacts on GitLab. Eventually
we'll want to provide GitHub releases with the `.compact.compressed.wasm` files (just
like [Polkadot](https://github.com/paritytech/polkadot/releases) does), but that's  a future problem.
