### PR TITLE
Introduce `rust-version` field to indicate Minimum Supported Rust Version

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/paritytech/canvas"
 repository = "https://github.com/paritytech/canvas"
 build = "build.rs"
 edition = "2021"
+rust-version = "1.56.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "GPL-3.0-only"
 edition = "2021"
+rust-version = "1.56.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
followup to #107 

`rust-version = "1.56.1"` introduced

For reference, I tried to get this to `cargo build` with 1.56.0 and it failed with
```
error: package `...` cannot be built because it requires rustc 1.56.1 or newer, while the currently active rustc version is 1.56.0
```
With `--ignore-rust-version` it _does_ build with 1.56.0, as expected.

